### PR TITLE
Check request params is an array before array_merge

### DIFF
--- a/src/Bugsnag/Request.php
+++ b/src/Bugsnag/Request.php
@@ -30,7 +30,7 @@ class Bugsnag_Request
 
             if (isset($_SERVER['REQUEST_METHOD']) && in_array(strtoupper($_SERVER['REQUEST_METHOD']), $methodsWithPayload)) {
                 parse_str(file_get_contents('php://input'),$params);
-                if(isset($requestData['request']['params']))
+                if (isset($requestData['request']['params']) && is_array($requestData['request']['params']))
                 {
                     $requestData['request']['params'] = array_merge($requestData['request']['params'],$params);
                 }


### PR DESCRIPTION
fixes bugsnag/bugsnag-php#116
